### PR TITLE
add examples for ESP32 via SPI lib

### DIFF
--- a/examples/esp32spi/lightdb_led/README.md
+++ b/examples/esp32spi/lightdb_led/README.md
@@ -1,0 +1,3 @@
+# Golioth LightDB LED Sample with CircuitPython
+
+This samples uses Golioth's LightDB State feature to control LEDs on a device.

--- a/examples/esp32spi/lightdb_led/code.py
+++ b/examples/esp32spi/lightdb_led/code.py
@@ -1,0 +1,85 @@
+import board
+import busio
+import board
+import digitalio
+import json
+from digitalio import DigitalInOut
+from digitalio import Direction
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+from adafruit_esp32spi import adafruit_esp32spi
+
+import golioth.golioth as Golioth
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+led0 = DigitalInOut(board.GP14)
+led0.direction = Direction.OUTPUT
+led1 = DigitalInOut(board.GP15)
+led1.direction = Direction.OUTPUT
+
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
+
+esp32_cs = digitalio.DigitalInOut(board.GP21)
+esp32_ready = digitalio.DigitalInOut(board.GP9)
+esp32_reset = digitalio.DigitalInOut(board.GP7)
+
+spi = busio.SPI(clock=board.GP22,MOSI=board.GP23,MISO=board.GP20)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+
+def connected(client):
+    print("Connected to Golioth!")
+    client.listen_lightdb_state_at_path("/led/#")
+
+
+def disconnected(client):
+    print("Disconnected from Golioth!")
+
+
+def on_message(client, path, message):
+    print("Change on lightdb path {0}: {1}".format(path, message))
+    if path == "led/":
+        data = json.loads(message)
+        if data is not None:
+            for k in data:
+                v = data[k]
+                if k == "0":
+                    led0.value = v
+                if k == "1":
+                    led1.value = v
+
+
+print("Resetting ESP module")
+esp.reset()
+print("Connected to AT software version", esp.firmware_version.decode())
+
+# secrets dictionary must contain 'ssid' and 'password' at a minimum
+print("Connecting...")
+esp.connect(secrets)
+print("IP address", esp.pretty_ip(esp.ip_address))
+
+Golioth.set_socket(socket, esp)
+golioth_client = Golioth.Client(secrets["psk_id"], secrets["psk"])
+golioth_client.on_connect = connected
+golioth_client.on_disconnect = disconnected
+golioth_client.on_lightdb_message = on_message
+
+print("Connecting to Golioth...")
+golioth_client.connect()
+
+while True:
+    try:
+        golioth_client.loop()
+    except (ValueError, RuntimeError) as e:
+        print("Failed to get data, retrying\n", e)
+        print("Resetting ESP module")
+        esp.reset()
+        esp.connect(secrets)
+        golioth_client.connect()
+        continue

--- a/examples/esp32spi/lightdb_led/secrets.py
+++ b/examples/esp32spi/lightdb_led/secrets.py
@@ -1,0 +1,6 @@
+secrets = {
+    "ssid": "",
+    "password": "",
+    "psk_id": "",
+    "psk": "",
+}

--- a/examples/esp32spi/logs/README.md
+++ b/examples/esp32spi/logs/README.md
@@ -1,0 +1,12 @@
+# Golioth Logs Sample with CircuitPython
+
+This samples uses Golioth's Device Logs feature. When the device is connected to the plaform, it will send some logs with the device information.
+
+Example:
+
+```
+$ goliothctl logs
+[2022-01-07T15:02:50Z] level:DEBUG  module:"default"  message:"Hello 1"  device_id:"61ae0d2495fd466888055c92" metadata:"{}"
+[2022-01-07T15:02:42Z] level:INFO  module:"espAT"  message:"connected"  device_id:"61ae0d2495fd466888055c92" metadata:"{"espATVersion":"AT version:2.2.0.0(90458f0 - ESP32C3 - Jun 18 2021 10:23:57)"}"
+[2022-01-07T15:02:38Z] level:DEBUG  module:"default"  message:"device connected from CircuitPython"  device_id:"61ae0d2495fd466888055c92" metadata:"{}"
+```

--- a/examples/esp32spi/logs/code.py
+++ b/examples/esp32spi/logs/code.py
@@ -1,0 +1,85 @@
+import board
+import busio
+import board
+import digitalio
+import time
+from digitalio import DigitalInOut
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+from adafruit_esp32spi import adafruit_esp32spi
+
+import golioth.golioth as Golioth
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+# Change the Debug Flag if you have issues with AT commands
+debugflag = False
+
+esp32_cs = digitalio.DigitalInOut(board.GP21)
+esp32_ready = digitalio.DigitalInOut(board.GP9)
+esp32_reset = digitalio.DigitalInOut(board.GP7)
+
+spi = busio.SPI(clock=board.GP22,MOSI=board.GP23,MISO=board.GP20)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+
+def connected(client):
+    print("Connected to Golioth!")
+    client.listen_hello()
+
+    client.log_debug("device connected from CircuitPython")
+    client.log_info({
+        'msg': "connected",
+        'module': "espSPI",
+        'espATVersion': esp.firmware_version
+    })
+
+
+def disconnected(client):
+    print("Disconnected from Golioth!")
+
+
+def on_hello(client, message):
+    print(message)
+
+
+print("Resetting ESP module")
+esp.reset()
+print("Connected to AT software version", esp.firmware_version.decode())
+
+# secrets dictionary must contain 'ssid' and 'password' at a minimum
+print("Connecting...")
+esp.connect(secrets)
+print("IP address", esp.pretty_ip(esp.ip_address))
+
+Golioth.set_socket(socket, esp)
+golioth_client = Golioth.Client(secrets["psk_id"], secrets["psk"])
+golioth_client.on_connect = connected
+golioth_client.on_disconnect = disconnected
+golioth_client.on_hello = on_hello
+
+print("Connecting to Golioth...")
+golioth_client.connect()
+
+last_check = 0
+i = 1
+while True:
+    try:
+        golioth_client.loop()
+        now = time.monotonic()
+        if now - last_check > 5:
+            golioth_client.log_debug("Hello "+str(i))
+            i = i + 1
+            last_check = now
+
+    except (ValueError, RuntimeError) as e:
+        print("Failed to get data, retrying\n", e)
+        print("Resetting ESP module")
+        esp.reset()
+        esp.connect(secrets)
+        golioth_client.connect()
+        continue

--- a/examples/esp32spi/logs/secrets.py
+++ b/examples/esp32spi/logs/secrets.py
@@ -1,0 +1,6 @@
+secrets = {
+    "ssid": "",
+    "password": "",
+    "psk_id": "",
+    "psk": "",
+}


### PR DESCRIPTION
These examples use the `adafruit_esp32spi` library which is a bit more maintained than the serial AT library.
This should work with all boards that use an external ESP32 for WiFi via SPI/Nina FW including the AirLift Shield/FeatherWings that Adafruit makes.

The API differs a bit unfortunately to the serial AT library but it works mostly the same.